### PR TITLE
CR1: Add Country field to Address

### DIFF
--- a/src/main/java/com/uams/model/Address.java
+++ b/src/main/java/com/uams/model/Address.java
@@ -42,6 +42,10 @@ public class Address {
     @Column(name = "state", nullable = false)
     private String state;
 
+    @NotBlank(message = "Country is required")
+    @Column(name = "country", nullable = false)
+    private String country;
+
     @NotBlank(message = "Pincode is required")
     @Column(name = "pincode", nullable = false)
     private String pincode;
@@ -58,6 +62,7 @@ public class Address {
                 ", street='" + street + '\'' +
                 ", city='" + city + '\'' +
                 ", state='" + state + '\'' +
+                ", country='" + country + '\'' +
                 ", pincode='" + pincode + '\'' +
                 '}';
     }

--- a/src/main/resources/templates/address/form.html
+++ b/src/main/resources/templates/address/form.html
@@ -37,6 +37,12 @@
             </div>
             
             <div class="mb-3">
+                <label for="country" class="form-label">Country</label>
+                <input type="text" class="form-control" id="country" th:field="*{country}" required>
+                <div class="text-danger" th:if="${#fields.hasErrors('country')}" th:errors="*{country}"></div>
+            </div>
+            
+            <div class="mb-3">
                 <label for="pincode" class="form-label">Pincode</label>
                 <input type="text" class="form-control" id="pincode" th:field="*{pincode}" required>
                 <div class="text-danger" th:if="${#fields.hasErrors('pincode')}" th:errors="*{pincode}"></div>

--- a/src/main/resources/templates/address/list.html
+++ b/src/main/resources/templates/address/list.html
@@ -29,13 +29,14 @@
                         <th>Street</th>
                         <th>City</th>
                         <th>State</th>
+                        <th>Country</th>
                         <th>Pincode</th>
                         <th>Actions</th>
                     </tr>
                 </thead>
                 <tbody>
                     <tr th:if="${addresses.empty}">
-                        <td colspan="7" class="text-center">No addresses found</td>
+                        <td colspan="8" class="text-center">No addresses found</td>
                     </tr>
                     <tr th:each="address : ${addresses}">
                         <td th:text="${address.addressId}"></td>
@@ -43,6 +44,7 @@
                         <td th:text="${address.street}"></td>
                         <td th:text="${address.city}"></td>
                         <td th:text="${address.state}"></td>
+                        <td th:text="${address.country}"></td>
                         <td th:text="${address.pincode}"></td>
                         <td>
                             <a th:href="@{/addresses/{id}/edit(id=${address.addressId})}" class="btn btn-sm btn-warning">Edit</a>

--- a/src/test/java/com/uams/controller/AddressControllerTest.java
+++ b/src/test/java/com/uams/controller/AddressControllerTest.java
@@ -59,15 +59,14 @@ public class AddressControllerTest {
         address.setCity("New York");
         address.setState("NY");
         address.setPincode("10001");
+        address.setCountry("USA");
         address.setUsers(new HashSet<>());
     }
 
     @Test
     void listAddresses_ShouldAddAddressesToModelAndReturnListView() throws Exception {
-        // Arrange
         when(addressService.getAllAddresses()).thenReturn(Arrays.asList(address));
 
-        // Act & Assert
         mockMvc.perform(get("/addresses"))
                 .andExpect(status().isOk())
                 .andExpect(model().attributeExists("addresses"))
@@ -78,7 +77,6 @@ public class AddressControllerTest {
 
     @Test
     void showCreateForm_ShouldAddNewAddressToModelAndReturnFormView() throws Exception {
-        // Act & Assert
         mockMvc.perform(get("/addresses/new"))
                 .andExpect(status().isOk())
                 .andExpect(model().attributeExists("address"))
@@ -87,14 +85,11 @@ public class AddressControllerTest {
 
     @Test
     void createAddress_WithValidData_ShouldSaveAddressAndRedirect() {
-        // Arrange
         when(bindingResult.hasErrors()).thenReturn(false);
         when(addressService.saveAddress(any(Address.class))).thenReturn(address);
 
-        // Act
         String viewName = addressController.createAddress(address, bindingResult, redirectAttributes);
 
-        // Assert
         assertEquals("redirect:/addresses", viewName);
         verify(addressService, times(1)).saveAddress(address);
         verify(redirectAttributes, times(1)).addFlashAttribute(eq("successMessage"), anyString());
@@ -102,23 +97,29 @@ public class AddressControllerTest {
 
     @Test
     void createAddress_WithInvalidData_ShouldReturnFormWithErrors() {
-        // Arrange
         when(bindingResult.hasErrors()).thenReturn(true);
 
-        // Act
         String viewName = addressController.createAddress(address, bindingResult, redirectAttributes);
 
-        // Assert
+        assertEquals("address/form", viewName);
+        verify(addressService, never()).saveAddress(any(Address.class));
+    }
+
+    @Test
+    void createAddress_WithEmptyCountry_ShouldReturnFormWithErrors() {
+        address.setCountry("");
+        when(bindingResult.hasErrors()).thenReturn(true);
+
+        String viewName = addressController.createAddress(address, bindingResult, redirectAttributes);
+
         assertEquals("address/form", viewName);
         verify(addressService, never()).saveAddress(any(Address.class));
     }
 
     @Test
     void showEditForm_WithExistingId_ShouldAddAddressToModelAndReturnFormView() throws Exception {
-        // Arrange
         when(addressService.getAddressById(1L)).thenReturn(Optional.of(address));
 
-        // Act & Assert
         mockMvc.perform(get("/addresses/1/edit"))
                 .andExpect(status().isOk())
                 .andExpect(model().attributeExists("address"))
@@ -129,10 +130,8 @@ public class AddressControllerTest {
 
     @Test
     void showEditForm_WithNonExistingId_ShouldRedirectToAddressesList() throws Exception {
-        // Arrange
         when(addressService.getAddressById(99L)).thenReturn(Optional.empty());
 
-        // Act & Assert
         mockMvc.perform(get("/addresses/99/edit"))
                 .andExpect(status().is3xxRedirection())
                 .andExpect(redirectedUrl("/addresses"));
@@ -142,14 +141,11 @@ public class AddressControllerTest {
 
     @Test
     void updateAddress_WithValidData_ShouldUpdateAddressAndRedirect() {
-        // Arrange
         when(bindingResult.hasErrors()).thenReturn(false);
         when(addressService.saveAddress(any(Address.class))).thenReturn(address);
 
-        // Act
         String viewName = addressController.updateAddress(1L, address, bindingResult, redirectAttributes);
 
-        // Assert
         assertEquals("redirect:/addresses", viewName);
         assertEquals(1L, address.getAddressId());
         verify(addressService, times(1)).saveAddress(address);
@@ -158,23 +154,29 @@ public class AddressControllerTest {
 
     @Test
     void updateAddress_WithInvalidData_ShouldReturnFormWithErrors() {
-        // Arrange
         when(bindingResult.hasErrors()).thenReturn(true);
 
-        // Act
         String viewName = addressController.updateAddress(1L, address, bindingResult, redirectAttributes);
 
-        // Assert
+        assertEquals("address/form", viewName);
+        verify(addressService, never()).saveAddress(any(Address.class));
+    }
+
+    @Test
+    void updateAddress_WithInvalidCountry_ShouldReturnFormWithErrors() {
+        address.setCountry("");
+        when(bindingResult.hasErrors()).thenReturn(true);
+
+        String viewName = addressController.updateAddress(1L, address, bindingResult, redirectAttributes);
+
         assertEquals("address/form", viewName);
         verify(addressService, never()).saveAddress(any(Address.class));
     }
 
     @Test
     void deleteAddress_ShouldDeleteAddressAndRedirect() throws Exception {
-        // Arrange
         doNothing().when(addressService).deleteAddress(1L);
 
-        // Act & Assert
         mockMvc.perform(get("/addresses/1/delete"))
                 .andExpect(status().is3xxRedirection())
                 .andExpect(redirectedUrl("/addresses"));

--- a/src/test/java/com/uams/service/AddressServiceImplTest.java
+++ b/src/test/java/com/uams/service/AddressServiceImplTest.java
@@ -38,6 +38,7 @@ public class AddressServiceImplTest {
         address1.setCity("New York");
         address1.setState("NY");
         address1.setPincode("10001");
+        address1.setCountry("USA");
 
         address2 = new Address();
         address2.setAddressId(2L);
@@ -46,6 +47,7 @@ public class AddressServiceImplTest {
         address2.setCity("Los Angeles");
         address2.setState("CA");
         address2.setPincode("90001");
+        address2.setCountry("USA");
     }
 
     @Test
@@ -59,7 +61,9 @@ public class AddressServiceImplTest {
         // Assert
         assertEquals(2, addresses.size());
         assertEquals(address1.getStreet(), addresses.get(0).getStreet());
+        assertEquals(address1.getCountry(), addresses.get(0).getCountry());
         assertEquals(address2.getStreet(), addresses.get(1).getStreet());
+        assertEquals(address2.getCountry(), addresses.get(1).getCountry());
         verify(addressRepository, times(1)).findAll();
     }
 
@@ -74,6 +78,7 @@ public class AddressServiceImplTest {
         // Assert
         assertTrue(result.isPresent());
         assertEquals(address1.getStreet(), result.get().getStreet());
+        assertEquals(address1.getCountry(), result.get().getCountry());
         verify(addressRepository, times(1)).findById(1L);
     }
 
@@ -101,6 +106,7 @@ public class AddressServiceImplTest {
         // Assert
         assertNotNull(savedAddress);
         assertEquals(address1.getStreet(), savedAddress.getStreet());
+        assertEquals(address1.getCountry(), savedAddress.getCountry());
         verify(addressRepository, times(1)).save(address1);
     }
 


### PR DESCRIPTION
This pull request implements the Country field feature for addresses as part of CR1.

Changes include:
1. Added Country field to Address model with validation
2. Updated Address form to include Country field
3. Updated Address list view to display Country field
4. Updated tests to cover Country field functionality

Related Jira tickets:
- EPMCDMETST-4423: Add Country field to Address (Feature)
- EPMCDMETST-4424: Add Country field to Address table
- EPMCDMETST-4425: Update Address screens with Country field
- EPMCDMETST-4426: Update Address API with Country field

Testing:
- Added unit tests for Country field validation
- Updated existing tests to include Country field
- Manual testing performed for form submission and display